### PR TITLE
fix crash when sim language is detected but unrecognized

### DIFF
--- a/java/app/grapheneos/setupwizard/action/WelcomeActions.kt
+++ b/java/app/grapheneos/setupwizard/action/WelcomeActions.kt
@@ -77,7 +77,7 @@ object WelcomeActions {
         val adapter = LocalePicker.constructAdapter(activity)
         val simLocale = getSimLocale() ?: return adapter
         var localeInfo: LocaleInfo? = null
-        for (index in 0..adapter.count) {
+        for (index in 0..<adapter.count) {
             val item = adapter.getItem(index)
             if (!item?.locale?.toLanguageTag().equals(simLocale.toLanguageTag())) continue
             Log.d(TAG, "constructLocaleAdapter: found simLocale $simLocale")


### PR DESCRIPTION
handle the case when telephony manager detects a sim locale, but the same is not recognised by `com.android.internal.app.LocalePicker`

fixes https://github.com/GrapheneOS/platform_packages_apps_SetupWizard2/issues/17